### PR TITLE
Update exn message when the `estimatedSize` is less than actual size

### DIFF
--- a/itext/itext.sign/itext/signatures/PdfSigner.cs
+++ b/itext/itext.sign/itext/signatures/PdfSigner.cs
@@ -811,7 +811,7 @@ namespace iText.Signatures {
                 .GetSignatureMechanismParameters());
             byte[] encodedSig = sgn.GetEncodedPKCS7(hash, sigtype, tsaClient, ocspList, crlBytes);
             if (estimatedSize < encodedSig.Length) {
-                throw new System.IO.IOException("Not enough space");
+                throw new System.IO.IOException($"Size of encoded signature was smaller than the estimated size. Expected {estimatedSize} but got {encodedSig.Length}");
             }
             byte[] paddedSig = new byte[estimatedSize];
             Array.Copy(encodedSig, 0, paddedSig, 0, encodedSig.Length);


### PR DESCRIPTION
The current message sounds unrelated and provides no insight into the actual issue.

To avoid changing the behaviour, only the exception message has been updated.