### PR TITLE
fix: use correct background layer accessor

### DIFF
--- a/itext/itext.sign/itext/signatures/PdfSigner.cs
+++ b/itext/itext.sign/itext/signatures/PdfSigner.cs
@@ -453,7 +453,7 @@ namespace iText.Signatures {
         // we might have to change around to GetSignatureField and operate on that
         public virtual PdfFormXObject GetBackgroundLayer()
         {
-            return appearance.GetBackgroundLayer();
+            return appearance.GetLayer0();
         }
 
         /// <summary>


### PR DESCRIPTION
The `GetBackgroundLayer` on appearance only works in specific cases.

This commit changes it to access `GetLayer0` instead as that is always set.

Fixes issue introduced by #7 